### PR TITLE
Update allinone-compute.json

### DIFF
--- a/roles/allinone-compute.json
+++ b/roles/allinone-compute.json
@@ -8,6 +8,7 @@
   },
   "chef_type": "role",
   "run_list": [
+    "role[os-ops-caching]",
     "role[os-compute-single-controller]",
     "role[os-compute-worker]",
     "recipe[openstack-common::openrc]"


### PR DESCRIPTION
Keystone can not fucntion properly without memcached.
Add role "os-ops-caching" into runlist to resolve this issue.
