### PR TITLE
update deprecated code

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://supermarket.getchef.com"
 
 cookbook 'apache2', '1.9.6'
 cookbook 'apt', '2.3.8'


### PR DESCRIPTION
when using berksfile in latest chef development kit we get:
DEPRECATED: Your Berksfile contains a site location pointing to the Opscode Community Site (site :opscode). Site locations have been replaced by the source location. Change this to: 'source "https://supermarket.getchef.com"' to remove this warning. For more information visit https://github.com/berkshelf/berkshelf/wiki/deprecated-locations
